### PR TITLE
Add a fallback if thumbnail_limit can't be fetched from gsettings

### DIFF
--- a/usr/bin/gnome-exe-thumbnailer
+++ b/usr/bin/gnome-exe-thumbnailer
@@ -185,7 +185,13 @@ case "$THEME" in
 esac
 
 INPUTFILE_SIZE=$(du -b "$INPUTFILE" | cut -f1 -d$'\t')
+# Try to fetch the max. size for thumbnailed executables from gsettings, but fall back to 10485760 bytes if that fails.
 THUMBNAIL_LIMIT=$(gsettings get org.gnome.nautilus.preferences thumbnail-limit | cut -f2 -d' ')
+
+if [[ ! "$THUMBNAIL_LIMIT" ]]
+then
+	THUMBNAIL_LIMIT=10485760
+fi
 
 
 if [[ ${INPUTFILE##*.} = 'msi' ]]


### PR DESCRIPTION
Closes GH-1.

In gnome-exe-thumbnailer 0.9.4, the new check for Nautilus' thumbnail size limit unfortunately broke setups that don't have Nautilus installed (e.g. on the Cinnamon DE). As org.gnome.nautilus.preferences doesn't exist, g-e-t errors on the size check and fails to thumbnail anything.

This patch addresses this by adding a fallback value of 10486760 bytes, the default in Nautilus.